### PR TITLE
Add a flag to turn on test imports

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -17,6 +17,7 @@ func main() {
 	app := kingpin.New("go2nix", "Nix derivations for Go packages")
 
 	saveCmd := app.Command("save", "Saves dependencies for cwd and current GOPATH")
+	testImports := saveCmd.Flag("test-imports", "Include test imports.").Short('t').Bool()
 
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case saveCmd.FullCommand():
@@ -28,7 +29,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := save(currPkg, goPath); err != nil {
+		if err := save(currPkg, goPath, *testImports); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/save.go
+++ b/save.go
@@ -42,14 +42,14 @@ type VendoredPackage struct {
 	PkgDir     string
 }
 
-func save(pkgName, goPath string) error {
+func save(pkgName, goPath string, testImports bool) error {
 
 	pkg, err := NewPackage(pkgName, goPath)
 	if err != nil {
 		return err
 	}
 
-	deps, err := findDeps(pkgName, goPath, true)
+	deps, err := findDeps(pkgName, goPath, testImports)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I found myself needing to not include test imports when running go2nix, but the behavior was not configurable via the CLI.

This is a breaking change since the default behavior would now be to not include test imports. Another option would be to have a `--no-test-imports` flag. What do you think?