### PR TITLE
Add an explicit dependency on prefetch commands

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,8 @@ buildGoPackage rec {
     wrapProgram $bin/bin/go2nix \
       ${lib.flip lib.concatMapStrings vcss (vcs: ''
         --prefix PATH : ${vcs}/bin \
-      '')}
+      '')} \
+      --prefix PATH : ${git}/bin
   '';
 
   extraSrcs = (builtins.attrValues rec {

--- a/default.nix
+++ b/default.nix
@@ -3,16 +3,31 @@ with import <nixpkgs> {};
 
 with goPackages;
 
+let
+  vcss = [
+    nix-prefetch-git
+    # nix-prefetch-svn
+    # nix-prefetch-bzr
+    # nix-prefetch-hg
+  ];
+in
+
 buildGoPackage rec {
   name = "go2nix-${version}";
   version = "dev";
 
-  buildInputs = [ go-bindata.bin tools.bin ];
+  buildInputs = [ makeWrapper go-bindata.bin tools.bin ];
   goPackagePath = "github.com/kamilchm/go2nix";
 
   src = ./.;
 
   preBuild = ''go generate ./...'';
+  postInstall = ''
+    wrapProgram $bin/bin/go2nix \
+      ${lib.flip lib.concatMapStrings vcss (vcs: ''
+        --prefix PATH : ${vcs}/bin \
+      '')}
+  '';
 
   extraSrcs = (builtins.attrValues rec {
     vcs = {


### PR DESCRIPTION
So go2nix don't rely anymore on the user having the prefetch commands in its `PATH`.

Depending only on Git by default, but can uncomment other needed VCSs.