### PR TITLE
Allow the package to reference Go

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,8 @@ buildGoPackage rec {
 
   preBuild = ''go generate ./...'';
 
+  allowGoReference = true;
+
   extraSrcs = (builtins.attrValues rec {
     vcs = {
       goPackagePath = "github.com/Masterminds/vcs";


### PR DESCRIPTION
Depends on NixOS/nixpkgs#13533.

Without access to `GOROOT`, go2nix was not able to find some native packages, for example:

```
# go2nix save
2016/02/28 00:26:58 cannot find package "errors" in any of:
        /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-go-1.5.3/share/go/src/errors (from $GOROOT)
        /.../src/errors (from $GOPATH)
```