### PR TITLE
Add an option to specify build tags

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -17,6 +17,7 @@ func main() {
 	app := kingpin.New("go2nix", "Nix derivations for Go packages")
 
 	saveCmd := app.Command("save", "Saves dependencies for cwd and current GOPATH")
+	buildTags := saveCmd.Flag("tags", "Build tags.").String()
 
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case saveCmd.FullCommand():
@@ -28,7 +29,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := save(currPkg, goPath); err != nil {
+		buildTagsList := strings.Split(*buildTags, ",")
+		if err := save(currPkg, goPath, buildTagsList); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/templates/default.nix
+++ b/templates/default.nix
@@ -10,6 +10,9 @@ buildGoPackage rec {
   rev = "[[ .Pkg.Revision ]]";
 
   buildInputs = [ go ];
+  [[ if ne .BuildTags "" ]]
+  buildFlags = "--tags [[ .BuildTags ]]";
+  [[ end ]]
   goPackagePath = "[[ .Pkg.ImportPath ]]";
 
   src = fetchgit {


### PR DESCRIPTION
The dependencies are fetched in the context of given build tags, and the `buildFlags` option is set with the according `-tags` in Nix expression output.