### PR TITLE
Make go2nix compatible with nix-prefetch-git 2015-12-13 update

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -12,11 +12,18 @@ func calculateHash(url, pathType string) (hash string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return hashFromNixPrefetch(prefetchOut)
+	return hashFromNixPrefetch(pathType, prefetchOut)
 }
 
-func hashFromNixPrefetch(prefetchOut []byte) string {
+func hashFromNixPrefetch(pathType string, prefetchOut []byte) string {
 	prefetchStr := strings.TrimSpace(string(prefetchOut))
 	prefetchLines := strings.Split(prefetchStr, "\n")
-	return prefetchLines[len(prefetchLines)-1]
+
+	// nix-prefetch-git after https://github.com/NixOS/nixpkgs/pull/11671
+	if pathType == "git" && prefetchLines[len(prefetchLines)-1][0] == '}' {
+		return prefetchLines[len(prefetchLines)-2]
+	}
+
+	// regular nix-prefetch-* output
+	return "  sha512 = \"" + prefetchLines[len(prefetchLines)-1] + "\""
 }

--- a/templates/default.nix
+++ b/templates/default.nix
@@ -15,7 +15,7 @@ buildGoPackage rec {
   src = fetchgit {
     inherit rev;
     url = "[[ .Pkg.VcsRepo ]]";
-    sha256 = "[[ .Pkg.Hash ]]";
+  [[ .Pkg.Hash ]]
   };
 
   extraSrcs = (builtins.attrValues rec {
@@ -25,7 +25,7 @@ buildGoPackage rec {
       src = fetch[[ $dep.VcsCommand ]] {
         url = "[[ $dep.VcsRepo ]]";
         rev = "[[ $dep.Revision ]]";
-        sha256 = "[[ $dep.Hash ]]";
+        [[ $dep.Hash ]]
       };
     };
     [[ range $vend := $dep.Vendored ]][[ $vend.Name ]] = {


### PR DESCRIPTION
This update from NixOS/nixpkgs#11671 makes it output a Nix expression instead of just the hash at the end, like:

    {
      url = "...";
      rev = "...";
      sha256 = "...";
    }

Now the `Hash` variable is the full line `  {{ HashType }} == "{{ Hash }}"` and is included as is in the template.