### PR TITLE
Fetch submodules when computing hash

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -7,7 +7,15 @@ import (
 )
 
 func calculateHash(url, pathType string) (hash string) {
-	prefetchCmd := exec.Command("nix-prefetch-"+pathType, url)
+	args := []string{}
+
+	if pathType == "git" {
+		// `fetchgit` passes this argument by default
+		args = append(args, "--fetch-submodules")
+	}
+
+	args = append(args, url)
+	prefetchCmd := exec.Command("nix-prefetch-"+pathType, args...)
 	prefetchOut, err := prefetchCmd.Output()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
That's the default behavior of `fetchgit`, and raw `fetchgit` is used in output Nix expression, so this previously caused hash conflicts when submodules were present.