### PR TITLE
Make go2nix compatible with nix-prefetch-git 2016-03-01 update

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -3,8 +3,15 @@ package main
 import (
 	"log"
 	"os/exec"
+	"encoding/json"
 	"strings"
 )
+
+type Package struct {
+    Url string `json:"url"`
+    Rev string `json:"rev"`
+    Sha256 string `json:"sha256"`
+}
 
 func calculateHash(url, pathType string) (hash string) {
 	prefetchCmd := exec.Command("nix-prefetch-"+pathType, url)
@@ -12,11 +19,23 @@ func calculateHash(url, pathType string) (hash string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return hashFromNixPrefetch(prefetchOut)
+	return hashFromNixPrefetch(pathType, prefetchOut)
 }
 
-func hashFromNixPrefetch(prefetchOut []byte) string {
+func hashFromNixPrefetch(pathType string, prefetchOut []byte) string {
 	prefetchStr := strings.TrimSpace(string(prefetchOut))
 	prefetchLines := strings.Split(prefetchStr, "\n")
-	return prefetchLines[len(prefetchLines)-1]
+
+	// nix-prefetch-git after https://github.com/NixOS/nixpkgs/pull/13584
+	if pathType == "git" && prefetchLines[len(prefetchLines)-1][0] == '}' {
+		var p Package
+		err := json.Unmarshal([]byte(prefetchStr), &p)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return p.Sha256
+	}
+
+	// regular nix-prefetch-* output
+	return "  sha512 = \"" + prefetchLines[len(prefetchLines)-1] + "\""
 }


### PR DESCRIPTION
This update from NixOS/nixpkgs#13584 makes it output a JSON expression instead of a Nix expression as in #6.