### PR TITLE
Fix regular nix-prefetch-* output handling

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -45,5 +45,5 @@ func hashFromNixPrefetch(pathType string, prefetchOut []byte) string {
 	}
 
 	// regular nix-prefetch-* output
-	return "  sha512 = \"" + prefetchLines[len(prefetchLines)-1] + "\""
+	return prefetchLines[len(prefetchLines)-1];
 }


### PR DESCRIPTION
I just realized I broke the normal nix-prefetch-* output parsing with #8, because I wrongly updated it from #6 (which included the full `sha256 = "...";`).

Sorry for the noise.