### PR TITLE
Remove merge - packages should have its own deps

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -43,19 +43,6 @@ func main() {
 		}
 	})
 
-	go2nix.Command("merge", "Takes deps from one file and tries to merge it into another one", func(cmd *cli.Cmd) {
-		srcFile := cmd.StringArg("SRC", "",
-			"File with dependencies to merge into DST")
-		dstFile := cmd.StringArg("DST", "",
-			"Where to merge dependencies?")
-
-		cmd.Action = func() {
-			if err := MergeDeps(*srcFile, *dstFile); err != nil {
-				log.Fatal(err)
-			}
-		}
-	})
-
 	go2nix.Run(os.Args)
 }
 

--- a/go2nix.1
+++ b/go2nix.1
@@ -9,13 +9,6 @@ go2nix \- Nix derivations for Go packages
 .B go2nix
 is a tool to extract dependency information from a Go package in an
 automated way.
-.SH COMMAND MERGE
-.B Synopsis
-.IP
-.B go2nix merge \ \fIsource\fP \ \fIdestination\fP
-.P
-.B Description
-.IP "The merge command takes deps from one file and tries to merge it into another one."
 .SH COMMAND SAVE
 .B Synopsis
 .IP


### PR DESCRIPTION
There's no Go dependency reuse in nixpkgs after
https://github.com/NixOS/nixpkgs/pull/17677
Moreover, after conversion of deps format from
json to nix, `go2nix merge` wasn't converted
and won't work with new deps.nix.