### PR TITLE
Fix goPath trimming in NewPackage func

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -54,16 +54,24 @@ func currentPackage(goPath string) (string, error) {
 		return "", err
 	}
 
-	for _, goPathDir := range strings.Split(goPath, ":") {
-		goPathSrc, err := filepath.Abs(filepath.Join(goPathDir, "/src"))
-		if err != nil {
-			continue
-		}
-		if strings.HasPrefix(currDir, goPathSrc) {
-			return strings.TrimPrefix(currDir, goPathSrc+"/"), nil
-		}
+	if packagePath, found := trimGopath(goPath, currDir); found {
+		return packagePath, nil
 	}
 
 	return "", fmt.Errorf("Current dir %v is outside of GOPATH(%v). "+
 		"Can't get current package name", currDir, goPath)
+}
+
+func trimGopath(goPath string, packagePath string) (trimmedPath string, trimmed bool) {
+	for _, goPathDir := range filepath.SplitList(goPath) {
+		goPathSrc, err := filepath.Abs(filepath.Join(goPathDir, "/src"))
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(packagePath, goPathSrc) {
+			return strings.TrimPrefix(packagePath, goPathSrc+"/"), true
+		}
+	}
+
+	return packagePath, false
 }

--- a/save.go
+++ b/save.go
@@ -104,7 +104,7 @@ func NewPackage(importPath string, goPath string) (*GoPackage, error) {
 			fullPath, err)
 	}
 
-	pkgRoot := strings.TrimPrefix(repoRoot, goPath+"/src/")
+	pkgRoot, _ := trimGopath(goPath, repoRoot)
 
 	if strings.Contains(pkgRoot, "/vendor/") {
 		return nil, nil
@@ -136,7 +136,7 @@ func NewPackage(importPath string, goPath string) (*GoPackage, error) {
 }
 
 func goPackageDir(importPath, goPath string) (string, error) {
-	for _, goPathDir := range strings.Split(goPath, ":") {
+	for _, goPathDir := range filepath.SplitList(goPath) {
 		expectedPath := filepath.Clean(goPathDir + "/src/" + importPath)
 		if _, err := os.Stat(expectedPath); err == nil {
 			return expectedPath, nil


### PR DESCRIPTION
Hi!

I have a list of paths as GOPATH, and I was getting absolute paths for all the `goPackagePath` values in my generated `deps.nix`.

So I refactored the gopath trimming used by `currentPackage()` into a separate function, and used that in `NewPackage()` instead of the `strings.TrimPrefix`that was there.