### PR TITLE
Use the source attribute to infer the repository URL

### DIFF
--- a/dep/solver.go
+++ b/dep/solver.go
@@ -20,6 +20,7 @@ type depLock struct {
 
 type depProject struct {
 	Name     string   `toml:"name"`
+	Source   string   `toml:"source"`
 	Revision string   `toml:"revision"`
 	Packages []string `toml:"packages"`
 }
@@ -59,7 +60,7 @@ func convertDeps(lock *depLock) (deps []go2nix.GoPackage) {
 	for _, p := range lock.Projects {
 		pkg := go2nix.GoPackage{
 			Name:        go2nix.ImportPath(p.Name),
-			Source:      &go2nix.PkgSource{Revision: p.Revision},
+			Source:      &go2nix.PkgSource{Url: p.Source, Revision: p.Revision},
 			SubPackages: p.Packages,
 		}
 

--- a/govcs/remote_repo_inferrer.go
+++ b/govcs/remote_repo_inferrer.go
@@ -12,9 +12,16 @@ import (
 type RemoteRepoInferrer struct{}
 
 func (s *RemoteRepoInferrer) Infer(pkg go2nix.GoPackage) (go2nix.GoPackage, error) {
-	repoRoot, err := vcs.RepoRootForImportPath(string(pkg.Name), false)
+	repo := string(pkg.Name)
+	// The repository url can be different from the import
+	// path. See the source attribute in the Gopkg.toml constraint
+	// section.
+	if pkg.Source != nil && pkg.Source.Url != "" {
+		repo = pkg.Source.Url
+	}
+	repoRoot, err := vcs.RepoRootForImportPath(repo, false)
 	if err != nil {
-		return pkg, fmt.Errorf("Unknown repo root for '%s': %v", pkg.Name, err)
+		return pkg, fmt.Errorf("Unknown repo root for '%s': %v", repo, err)
 	}
 
 	src := &go2nix.PkgSource{


### PR DESCRIPTION
It is possible to use a fork of a Go project. In this case, the
repository URL is different from the import path. This is implement by
the "source" attribute in the Gopkg.toml constraint section.
So, if the source attribute exists, we use it instead of the import
path.